### PR TITLE
Provide a more helpful error message when query model type is omitted

### DIFF
--- a/lib/mappers/memory.js
+++ b/lib/mappers/memory.js
@@ -19,6 +19,10 @@ function MemoryMapper () {
 	}
 
 	function getCollection (model) {
+		if (!(model.prototype instanceof Model)) {
+			throw new Error("Model type does not inherit from Model");
+		}
+
 		var className  = model.name.toLowerCase();
 		var collection = map[className];
 

--- a/test/mappers/memory_spec.js
+++ b/test/mappers/memory_spec.js
@@ -159,6 +159,24 @@ describe("A memory mapper", function () {
 				});
 			});
 		});
+
+		describe("without passing a model type", function () {
+			var mapper = new MemoryMapper();
+
+			var result;
+
+			before(function () {
+				return mapper.find({ name : "foo" })
+				.catch(function (err) {
+					result = err;
+				});
+			});
+
+			it("throws a useful error", function () {
+				expect(result, "error").to.be.an.instanceOf(Error);
+				expect(result.message, "message").to.match(/model type/i);
+			});
+		});
 	});
 
 	describe("looking up an individual record", function () {
@@ -204,6 +222,22 @@ describe("A memory mapper", function () {
 
 			it("returns a model instance", function () {
 				expect(result, "type").to.be.an.instanceOf(Test);
+			});
+		});
+
+		describe("without passing a model type", function () {
+			var result;
+
+			before(function () {
+				return mapper.findOne({ name : "foo" })
+				.catch(function (err) {
+					result = err;
+				});
+			});
+
+			it("throws a useful error", function () {
+				expect(result, "error").to.be.an.instanceOf(Error);
+				expect(result.message, "message").to.match(/model type/i);
 			});
 		});
 	});


### PR DESCRIPTION
Currently, omitting the model type when using `find` or `findOne` creates somewhat opaque errors. Or, worse, if you pass a generic object with a `name` attribute as the first parameter, you may not get an error at all.
